### PR TITLE
chore: use logger as main object for assignment otherwise some method…

### DIFF
--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -90,7 +90,7 @@ function createLogger({
 
   // for any reason spread operator complain :)
   // tslint:disable-next-line prefer-object-spread
-  return Object.assign({}, logger, {
+  return Object.assign(logger, {
     getStream: (httpLogLevel: LogLevelType) => ({
       // @ts-ignore
       write: (...args: any[]) => this.logger[httpLogLevel](...args),


### PR DESCRIPTION
… are not available (like .on)