### PR TITLE
chore: add ICMS job status enum

### DIFF
--- a/packages/constants/src/icms.ts
+++ b/packages/constants/src/icms.ts
@@ -81,6 +81,13 @@ export const JOB_STATUSES = [
   {id: 103, status: 'Re-open'},
 ];
 
+export enum JOB_STATUS {
+  CLOSED = 9,
+  DRAFT = 83,
+  OPEN = 102,
+  REOPEN = 103,
+};
+
 export const DISTRICTS = [
   {
     id: 1,


### PR DESCRIPTION
adding an enum for ICMS job statuses so it's easier to use it rather than traversing the array of `JOB_STAUSES`