### PR TITLE
fix: added keepAliveTimeout and headersTimeout

### DIFF
--- a/packages/server-boilerplate-middleware/test/server.js
+++ b/packages/server-boilerplate-middleware/test/server.js
@@ -36,6 +36,11 @@ server.use('*', (req, res) => {
   });
 });
 const serverInstance = server.listen(35349);
+
+server.keepAliveTimeout = (process.env.SERVER_TIMEOUT || 5) * 1000;
+// This should be bigger than `keepAliveTimeout + your server's expected response time`
+server.headersTimeout = (process.env.SERVER_TIMEOUT || 10) * 1000;
+
 serverInstance.on('listening', () => {
   logger.info(`Listening on: http://localhost:${serverInstance.address().port}`);
   logger.info(`Proxying to : ${proxyPath}`);


### PR DESCRIPTION
Attempt to fix the 502 errors we are getting occasionally (but regularly) by allowing us to modify the timeout period.

Default node timeout is 5s, this allows us to increase the timeout to 10s to match Linkerd's timeout period.