### PR TITLE
fix: renamed env for server timeout

### DIFF
--- a/packages/server-boilerplate-middleware/test/server.js
+++ b/packages/server-boilerplate-middleware/test/server.js
@@ -37,9 +37,9 @@ server.use('*', (req, res) => {
 });
 const serverInstance = server.listen(35349);
 
-server.keepAliveTimeout = (process.env.SERVER_TIMEOUT || 5) * 1000;
+server.keepAliveTimeout = (process.env.KEEP_ALIVE_TIMEOUT || 5) * 1000;
 // This should be bigger than `keepAliveTimeout + your server's expected response time`
-server.headersTimeout = (process.env.SERVER_TIMEOUT || 10) * 1000;
+server.headersTimeout = (process.env.HEADERS_TIMEOUT || 10) * 1000;
 
 serverInstance.on('listening', () => {
   logger.info(`Listening on: http://localhost:${serverInstance.address().port}`);


### PR DESCRIPTION
renamed `SERVER_TIMEOUT` to individual env vars so that we can control the headers timeout to be greater than keep alive.