### PR TITLE
fix: set HEADERS_TIMEOUT default to 60s

### DIFF
--- a/packages/server-boilerplate-middleware/test/server.js
+++ b/packages/server-boilerplate-middleware/test/server.js
@@ -39,7 +39,7 @@ const serverInstance = server.listen(35349);
 
 server.keepAliveTimeout = (process.env.KEEP_ALIVE_TIMEOUT || 5) * 1000;
 // This should be bigger than `keepAliveTimeout + your server's expected response time`
-server.headersTimeout = (process.env.HEADERS_TIMEOUT || 10) * 1000;
+server.headersTimeout = (process.env.HEADERS_TIMEOUT || 60) * 1000;
 
 serverInstance.on('listening', () => {
   logger.info(`Listening on: http://localhost:${serverInstance.address().port}`);


### PR DESCRIPTION
Change HEADERS_TIMEOUT to be the default of 60s as per NodeJS documentation
- https://nodejs.org/api/http.html#http_server_headerstimeout